### PR TITLE
Pin xformers==0.0.24 to resolve conflict with torch==2.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "transformers==4.37.2", "datasets",
     "lm_eval==0.3.0", "texttable",
     "toml", "attributedict",
-    "xformers", "protobuf",
+    "xformers==0.0.24", "protobuf",
     "ninja", "seaborn", 
     "jieba", "fuzzywuzzy", "rouge",
     "gradio==3.35.2", "gradio_client==0.2.9",


### PR DESCRIPTION
## Summary
- Pin `xformers==0.0.24` in `pyproject.toml` to resolve compatibility issue with `torch==2.2.0`
- Latest unpinned `xformers` requires PyTorch 2.3+, which conflicts with the existing `torch==2.2.0` pin
- `xformers==0.0.24` is the last version compatible with PyTorch 2.2

Fixes #76

## Test plan
- [ ] Verify `pip install -e .` succeeds without dependency conflicts
- [ ] Verify xformers imports correctly alongside torch 2.2.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)